### PR TITLE
site_prism implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem 'rspec'
 gem 'capybara'
 gem 'selenium-webdriver'
+gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    site_prism (2.9)
+      addressable (>= 2.3.3, < 3.0)
+      capybara (>= 2.1, < 3.0)
     websocket (1.2.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -53,6 +56,7 @@ DEPENDENCIES
   capybara
   rspec
   selenium-webdriver
+  site_prism
 
 BUNDLED WITH
    1.13.5

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -17,7 +17,7 @@ require 'site_prism'
 
 class SearchFieldSection < SitePrism::Section
   element :text_input, '#lst-ib'
-  element :voice_imput, '.gsri_a'
+  element :voice_input, '.gsri_a'
   element :search_button, '.sbico'
 end
 
@@ -25,7 +25,6 @@ class SearchResultSection < SitePrism::Section
   element :title, '.r'
   element :url, '.f.kv'
   element :description, '.st'
-
 end
 
 class Page < SitePrism::Page
@@ -33,6 +32,10 @@ class Page < SitePrism::Page
 
   def initialize
     Capybara.current_driver = :selenium
+  end
+
+  def navigate_to_home_page
+    self.load
   end
 end
 
@@ -44,59 +47,16 @@ end
 class SearchResults < Page
   section :search_field, SearchFieldSection, '.sbibod'
   sections :search_results, SearchResultSection, '.rc'
+
+  def first_result_title
+    search_results.first.title.text
+  end
+
+  def first_result_url
+    search_results.first.url.text
+  end
+
+  def first_result_description
+    search_results.first.description.text
+  end
 end
-
-
-
-# class Page
-#   include Capybara::DSL
-
-#   def initialize
-#     Capybara.current_driver = :selenium
-#   end
-
-#   def enter_keyword(keyword)
-#     fill_in 'q', with: keyword
-#     # locator = params[:im_feeling_lucky] ? '.sbsb_i.sbqs_b' : '.lsb'
-#     find('.sbico', match: :first).click
-#   end
-
-#   def parse_all_sites
-#     within('.srg') do
-#       site_list = []
-#       all('._Rm').each { |i| site_list << i.text }
-#       site_list
-#     end
-#   end
-
-#   def first_result_title
-#     parse_first_result(:title)
-#   end
-
-#   def first_result_url
-#     parse_first_result(:url)
-#   end
-
-#   def first_result_description
-#     parse_first_result(:description)
-#   end
-
-#   private
-
-#   def parse_first_result(destination)
-#     locator =
-#       case destination
-#         when :title
-#           '.r'
-#         when :url
-#           '.f.kv'
-#         when :description
-#           '.st'
-#       end
-
-#     within(find('.rc', match: :first)) do
-#       find(locator).text
-#     end
-#   end
-
-# end

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -2,6 +2,7 @@ require 'capybara'
 require 'capybara/dsl'
 require 'capybara/rspec'
 require 'uri'
+require 'site_prism'
 
 # # workaround to keep browser alive for debugging after test completion
 # Capybara::Selenium::Driver.class_eval do
@@ -14,55 +15,88 @@ require 'uri'
 #   end
 # end
 
-class Page
+class SearchFieldSection < SitePrism::Section
+  element :text_input, '#lst-ib'
+  element :voice_imput, '.gsri_a'
+  element :search_button, '.sbico'
+end
+
+class SearchResultSection < SitePrism::Section
+  element :title, '.r'
+  element :url, '.f.kv'
+  element :description, '.st'
+
+end
+
+class Page < SitePrism::Page
   include Capybara::DSL
 
   def initialize
     Capybara.current_driver = :selenium
   end
-
-  def enter_keyword(keyword)
-    fill_in 'q', with: keyword
-    # locator = params[:im_feeling_lucky] ? '.sbsb_i.sbqs_b' : '.lsb'
-    find('.sbico', match: :first).click
-  end
-
-  def parse_all_sites
-    within('.srg') do
-      site_list = []
-      all('._Rm').each { |i| site_list << i.text }
-      site_list
-    end
-  end
-
-  def first_result_title
-    parse_first_result(:title)
-  end
-
-  def first_result_url
-    parse_first_result(:url)
-  end
-
-  def first_result_description
-    parse_first_result(:description)
-  end
-
-  private
-
-  def parse_first_result(destination)
-    locator =
-      case destination
-        when :title
-          '.r'
-        when :url
-          '.f.kv'
-        when :description
-          '.st'
-      end
-
-    within(find('.rc', match: :first)) do
-      find(locator).text
-    end
-  end
-
 end
+
+class Home < Page
+  set_url 'https://www.google.com'
+  section :search_field, SearchFieldSection, '.sbibod'
+end
+
+class SearchResults < Page
+  section :search_field, SearchFieldSection, '.sbibod'
+  sections :search_results, SearchResultSection, '.rc'
+end
+
+
+
+# class Page
+#   include Capybara::DSL
+
+#   def initialize
+#     Capybara.current_driver = :selenium
+#   end
+
+#   def enter_keyword(keyword)
+#     fill_in 'q', with: keyword
+#     # locator = params[:im_feeling_lucky] ? '.sbsb_i.sbqs_b' : '.lsb'
+#     find('.sbico', match: :first).click
+#   end
+
+#   def parse_all_sites
+#     within('.srg') do
+#       site_list = []
+#       all('._Rm').each { |i| site_list << i.text }
+#       site_list
+#     end
+#   end
+
+#   def first_result_title
+#     parse_first_result(:title)
+#   end
+
+#   def first_result_url
+#     parse_first_result(:url)
+#   end
+
+#   def first_result_description
+#     parse_first_result(:description)
+#   end
+
+#   private
+
+#   def parse_first_result(destination)
+#     locator =
+#       case destination
+#         when :title
+#           '.r'
+#         when :url
+#           '.f.kv'
+#         when :description
+#           '.st'
+#       end
+
+#     within(find('.rc', match: :first)) do
+#       find(locator).text
+#     end
+#   end
+
+# end

--- a/spec/features/basic_search_spec.rb
+++ b/spec/features/basic_search_spec.rb
@@ -4,14 +4,9 @@ require 'page'
 
 RSpec.feature "Verify query search results" do
 
-  # subject { Page.new }
-  # subject { Home.new }
-
   background do
-    # subject.visit 'https://google.com'
-    # subject.enter_keyword keyword
-  @page = Home.new
-    @page.load
+    @page = Home.new
+    @page.navigate_to_home_page
     @page.wait_for_search_field(3)
     @page.search_field.text_input.set keyword
     @page.search_field.search_button.click
@@ -25,15 +20,15 @@ RSpec.feature "Verify query search results" do
         given(:keyword) {'monster'}
 
         scenario "Title contains inputted keyword Upcase" do
-          expect(@page.search_results.first.title.text).to include(keyword.capitalize)
+          expect(@page.first_result_title).to include(keyword.capitalize)
         end
 
         scenario "URL contains inputted keyword Downcase" do
-          expect(@page.search_results.first.url.text).to include(keyword.downcase)
+          expect(@page.first_result_url).to include(keyword.downcase)
         end
 
         scenario "Description contains inputted keyword Upcase" do
-          expect(@page.search_results.first.description.text).to include(keyword.capitalize)
+          expect(@page.first_result_description).to include(keyword.capitalize)
         end
       end # context downcase
 
@@ -42,15 +37,15 @@ RSpec.feature "Verify query search results" do
         given(:keyword) {'Monster'}
 
         scenario "Title contains inputted keyword Upcase" do
-          expect(@page.search_results.first.title.text).to include(keyword.capitalize)
+          expect(@page.first_result_title).to include(keyword.capitalize)
         end
 
         scenario "URL contains inputted keyword Downcase" do
-          expect(@page.search_results.first.url.text).to include(keyword.downcase)
+          expect(@page.first_result_url).to include(keyword.downcase)
         end
 
         scenario "Description contains inputted keyword Upcase" do
-          expect(@page.search_results.first.description.text).to include(keyword.capitalize)
+          expect(@page.first_result_description).to include(keyword.capitalize)
         end
       end # context upcase
 
@@ -58,29 +53,29 @@ RSpec.feature "Verify query search results" do
         given(:keyword) {'mONSteR'}
 
         scenario "Title contains inputted keyword Upcase" do
-          expect(@page.search_results.first.title.text).to include(keyword.capitalize)
+          expect(@page.first_result_title).to include(keyword.capitalize)
         end
 
         scenario "URL contains inputted keyword Downcase" do
-          expect(@page.search_results.first.url.text).to include(keyword.downcase)
+          expect(@page.first_result_url).to include(keyword.downcase)
         end
 
         scenario "Description contains inputted keyword Upcase" do
-          expect(@page.search_results.first.description.text).to include(keyword.capitalize)
+          expect(@page.first_result_description).to include(keyword.capitalize)
         end
       end # context mixed
     end # context ignore
 
 
     context "cyryllic symbols" do
-      given(:keyword) {'Монстр'}
+      given(:keyword) {'Колобок'}
 
       scenario "Title contains inputted cyryllic keyword" do
-        expect(@page.search_results.first.title.text).to include(keyword.capitalize)
+        expect(@page.first_result_title).to include(keyword.capitalize)
       end
 
       scenario "Description contains inputted cyryllic keyword" do
-        expect(@page.search_results.first.description.text).to include(keyword.capitalize)
+        expect(@page.first_result_description).to include(keyword.capitalize)
       end
     end
   end # feature one-word
@@ -90,11 +85,11 @@ RSpec.feature "Verify query search results" do
     given(:keyword) {'Buy Car Online'}
 
     scenario "Title contains inputted keyword" do
-      expect(@page.search_results.first.title.text).to include('Buy', 'Car', 'Online')
+      expect(@page.first_result_title).to include('Buy', 'Car', 'Online')
     end
 
     scenario "Description contains inputted keyword" do
-      expect(@page.search_results.first.description.text).to include('buy', 'car', 'online')
+      expect(@page.first_result_description).to include('buy', 'car', 'online')
     end
   end
 end # feature verify search

--- a/spec/features/basic_search_spec.rb
+++ b/spec/features/basic_search_spec.rb
@@ -4,11 +4,19 @@ require 'page'
 
 RSpec.feature "Verify query search results" do
 
-  subject { Page.new }
+  # subject { Page.new }
+  # subject { Home.new }
 
   background do
-    subject.visit 'https://google.com'
-    subject.enter_keyword keyword
+    # subject.visit 'https://google.com'
+    # subject.enter_keyword keyword
+  @page = Home.new
+    @page.load
+    @page.wait_for_search_field(3)
+    @page.search_field.text_input.set keyword
+    @page.search_field.search_button.click
+    @page = SearchResults.new
+    @page.wait_for_search_results(3)
   end
 
   feature "Use one-word keyword" do
@@ -17,15 +25,15 @@ RSpec.feature "Verify query search results" do
         given(:keyword) {'monster'}
 
         scenario "Title contains inputted keyword Upcase" do
-          expect(subject.first_result_title).to include(keyword.capitalize)
+          expect(@page.search_results.first.title.text).to include(keyword.capitalize)
         end
 
         scenario "URL contains inputted keyword Downcase" do
-          expect(subject.first_result_url).to include(keyword.downcase)
+          expect(@page.search_results.first.url.text).to include(keyword.downcase)
         end
 
         scenario "Description contains inputted keyword Upcase" do
-          expect(subject.first_result_description).to include(keyword.capitalize)
+          expect(@page.search_results.first.description.text).to include(keyword.capitalize)
         end
       end # context downcase
 
@@ -34,15 +42,15 @@ RSpec.feature "Verify query search results" do
         given(:keyword) {'Monster'}
 
         scenario "Title contains inputted keyword Upcase" do
-          expect(subject.first_result_title).to include(keyword.capitalize)
+          expect(@page.search_results.first.title.text).to include(keyword.capitalize)
         end
 
         scenario "URL contains inputted keyword Downcase" do
-          expect(subject.first_result_url).to include(keyword.downcase)
+          expect(@page.search_results.first.url.text).to include(keyword.downcase)
         end
 
         scenario "Description contains inputted keyword Upcase" do
-          expect(subject.first_result_description).to include(keyword.capitalize)
+          expect(@page.search_results.first.description.text).to include(keyword.capitalize)
         end
       end # context upcase
 
@@ -50,15 +58,15 @@ RSpec.feature "Verify query search results" do
         given(:keyword) {'mONSteR'}
 
         scenario "Title contains inputted keyword Upcase" do
-          expect(subject.first_result_title).to include(keyword.capitalize)
+          expect(@page.search_results.first.title.text).to include(keyword.capitalize)
         end
 
         scenario "URL contains inputted keyword Downcase" do
-          expect(subject.first_result_url).to include(keyword.downcase)
+          expect(@page.search_results.first.url.text).to include(keyword.downcase)
         end
 
         scenario "Description contains inputted keyword Upcase" do
-          expect(subject.first_result_description).to include(keyword.capitalize)
+          expect(@page.search_results.first.description.text).to include(keyword.capitalize)
         end
       end # context mixed
     end # context ignore
@@ -68,11 +76,11 @@ RSpec.feature "Verify query search results" do
       given(:keyword) {'Монстр'}
 
       scenario "Title contains inputted cyryllic keyword" do
-        expect(subject.first_result_title).to include(keyword.capitalize)
+        expect(@page.search_results.first.title.text).to include(keyword.capitalize)
       end
 
       scenario "Description contains inputted cyryllic keyword" do
-        expect(subject.first_result_description).to include(keyword.capitalize)
+        expect(@page.search_results.first.description.text).to include(keyword.capitalize)
       end
     end
   end # feature one-word
@@ -81,14 +89,12 @@ RSpec.feature "Verify query search results" do
   feature "Use multi-word keyword" do
     given(:keyword) {'Buy Car Online'}
 
-    before { subject.enter_keyword 'Buy Car Online' }
-
     scenario "Title contains inputted keyword" do
-      expect(subject.first_result_title).to include('Buy', 'Car', 'Online')
+      expect(@page.search_results.first.title.text).to include('Buy', 'Car', 'Online')
     end
 
     scenario "Description contains inputted keyword" do
-      expect(subject.first_result_description).to include('buy', 'car', 'online')
+      expect(@page.search_results.first.description.text).to include('buy', 'car', 'online')
     end
   end
 end # feature verify search


### PR DESCRIPTION
- add site_prism dependencies
- reorganize page pattern to follow the site_prism convention
- change behavior in the spec itself:
  -- all operations are now invoked and described in the background/before section;
  -- can't invoke page instance via subject anymore, thus had to return to @page variable

NOTE: this is kinda raw draft just to show the first implementation of the site_prism gem