### PR TITLE
group_search and domain_search specs

### DIFF
--- a/lib/additional_methods.rb
+++ b/lib/additional_methods.rb
@@ -1,0 +1,24 @@
+
+class String
+  def without_quotes
+    fail("object should be string") unless self.class == String
+    quotes = ["\"", "'"]
+    quotes.each { |i| self.gsub!(i, '') }
+    self
+  end
+
+  def without_domain
+    fail("object should be string") unless self.class == String
+    domain = self._get_domain
+    self.gsub!(domain, '').strip
+  end
+
+  def domain
+    fail("object should be string") unless self.class == String
+    self._get_domain.gsub('site:', '')
+  end
+
+  def _get_domain
+    /(\S*(com|net|co|ru))/.match(self)[0]
+  end
+end

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -3,6 +3,7 @@ require 'capybara/dsl'
 require 'capybara/rspec'
 require 'uri'
 require 'site_prism'
+require 'additional_methods.rb'
 
 # # workaround to keep browser alive for debugging after test completion
 # Capybara::Selenium::Driver.class_eval do
@@ -67,10 +68,25 @@ class SearchResults < Page
   end
 
   def first_result_url
-    search_results.first.url.text
+    result = search_results.first.url.text
+    symbols_to_replace = ['_', '-']
+    symbols_to_replace.each { |s| result.gsub!(s, ' ') }
+    result
   end
 
   def first_result_description
     search_results.first.description.text
+  end
+
+  def all_titles
+    search_results.map { |result| result.title.text.downcase }
+  end
+
+  def all_urls
+    search_results.map { |result| result.url.text }
+  end
+
+  def all_descriptions
+    search_results.map { |result| result.description.text.downcase }
   end
 end

--- a/spec/features/basic_search_spec.rb
+++ b/spec/features/basic_search_spec.rb
@@ -1,8 +1,8 @@
-# spec/register_down_spec.rb
+# spec/features/register_down_spec.rb
 
 require 'page'
 
-feature "Verify query search results" do
+feature "Verify basic query search results" do
 
   background do
     @page = Home.new

--- a/spec/features/domain_search_spec.rb
+++ b/spec/features/domain_search_spec.rb
@@ -1,0 +1,55 @@
+# spec/features/domain_search_spec.rb
+
+require 'page'
+
+feature "Verify specific domain search results" do
+
+  background do
+    @page = Home.new
+    @page.navigate_to_home_page
+    @page.fill_search_field_with keyword
+    @page = @page.navigate_and_parse_search_page
+  end
+
+  feature "Use keyword with domain" do
+    given(:keyword) {'liverpool soccer.com'}
+
+    scenario "All titles contain keyword" do
+      # expect(@page.all_titles).to all( include(keyword.without_domain) )
+# smth is wrong with 'all' mathcher, thus ugly workaround had to be reinvented
+      expect(@page.all_titles).to satisfy do |v|
+# also .without_domain method results nil if invoced inside include? block
+# so I had to declare a variable to be passed there
+        matcher = keyword.without_domain
+        v.all? { |s| s.include?(matcher) }
+      end
+    end
+
+    scenario "Not all results belong to chosen domain" do
+      # expect(@page.all_urls).not_to all( include(keyword.domain) )
+      expect(@page.all_urls).not_to satisfy do |v|
+        v.all? { |s| s.include?(keyword.domain) }
+      end
+    end
+  end
+
+  feature"Use keyword with domain using 'site:' feature" do
+    given(:keyword) {'manchester site:soccer.com'}
+
+    scenario "All titles contain keyword" do
+      # expect(@page.first_result_title).to include(keyword.without_domain)
+      expect(@page.all_titles).to satisfy do |v|
+        matcher = keyword.without_domain
+        v.all? { |s| s.include?(matcher) }
+      end
+    end
+
+    scenario "All results belong to chosen domain" do
+      # expect(@page.all_urls).to all( include(keyword.domain) )
+      expect(@page.all_urls).to satisfy do |v|
+        v.all? { |s| s.include?(keyword.domain) }
+      end
+    end
+  end
+
+end

--- a/spec/features/groups_search_spec.rb
+++ b/spec/features/groups_search_spec.rb
@@ -1,0 +1,45 @@
+# spec/features/group_search_spec.rb
+
+require 'page'
+
+feature "Verify 'Exact Search' feature" do
+
+  background do
+    @page = Home.new
+    @page.navigate_to_home_page
+    @page.fill_search_field_with keyword
+    @page = @page.navigate_and_parse_search_page
+  end
+
+  feature "Use two-word keyword without quotes" do
+    given(:keyword) {'exact search'}
+
+    scenario "Title doesn't contain full keyword" do
+      expect(@page.first_result_title).not_to include(keyword)
+    end
+
+    scenario "URL doesn't contain full keyword" do
+      expect(@page.first_result_url).not_to include(keyword)
+    end
+
+    scenario "Description doesn't contain full keyword" do
+      expect(@page.first_result_description).not_to include(keyword)
+    end
+  end
+
+  feature "Use two-word keyword with quotes" do
+    given(:keyword) {'"exact search"'}
+
+    scenario "Title contains full keyword" do
+      expect(@page.first_result_title).to include(keyword.without_quotes)
+    end
+
+    scenario "URL contains full keyword" do
+      expect(@page.first_result_url).to include(keyword.without_quotes)
+    end
+
+    scenario "Description contains full keyword" do
+      expect(@page.first_result_description).to include(keyword.without_quotes)
+    end
+  end
+end


### PR DESCRIPTION
- additional file is added to add some String method for better readability
- there're some problems in domain_search_spec.rb which are briefly described there. I spent a lot of time trying to discover the reasons, but without any result. So I had to implement some workarounds which uglify the spec readability pretty much.